### PR TITLE
Updated to use es5 because fly didn't recognize it

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
-const Imagemin = require("imagemin")
+var Imagemin = require("imagemin")
 
-let min = function(data, options, cb) {
-  let imagemin = new Imagemin()
+var min = function(data, options, cb) {
+  var imagemin = new Imagemin()
         .src(data)
         .use(Imagemin.gifsicle({interlaced: options.interlaced}))
         .use(Imagemin.jpegtran({progressive: options.progressive}))
@@ -13,7 +13,7 @@ let min = function(data, options, cb) {
 
   imagemin.run((err, files) => {
     if (err) {
-      console.error(`imagemin error in ${err}`)
+      console.error('imagemin error in ' + err)
 
       return
     }
@@ -22,8 +22,9 @@ let min = function(data, options, cb) {
   })
 }
 
-export default function () {
-  this.filter("imagemin", (data, options) => {
+module.exports = function imagemin() {
+  this.filter('imagemin', function(data, options) {
     return this.defer(min)(data, options)
   })
 }
+


### PR DESCRIPTION
When I tried to use this package I kept getting this error.

```
stack:
  - Error: Did you forget to `npm i -D fly-imagemin`?
  -     at ~/Sites/styleguide.local/site/n/node_modules/fly/lib/fly.js 66:10
  -     at Array.forEach (native)
  -     at new Fly (~/Sites/styleguide.local/site/n/node_modules/fly/lib/fly.js 64:10)
  -     at Object.module.exports [as spawn] (~/Sites/styleguide.local/site/n/node_modules/fly/lib/cli/spawn.js 20:9)
  -     at [object Generator].next (native)
  -     at onFulfilled (~/Sites/styleguide.local/site/n/node_modules/co/index.js 65:19)
```

I assumed it was because it was trying to pull in the es6 version. If you update it to use es5 it works just fine. This happened to me using Node: v5.9.1, and I was also using `fly-esnext`.

I figured it would be more work to add babel to the repo than it would be worth so I just change it to use es5 instead.
